### PR TITLE
emacspeak refactor

### DIFF
--- a/config.el
+++ b/config.el
@@ -1,6 +1,48 @@
+;; config.el, the configuration file for Doom Emacs.
+;; Generated from config.org, do not manually edit.
+
+(add-hook 'after-init-hook (load "~/.doom.d/esp-prepare.el"))
+
+(setq user-full-name "Hunter Jozwiak"
+user-mail-address "hunter.t.joz@gmail.com")
+
+(setq doom-theme 'doom-one)
+
+(setq org-directory "~/org")
+
+(setq display-line-numbers-type nil)
+
 ;; In preparation for the loading of Emacspeak
 ;; Set the speech rate, so as to not go insane.
 (after! emacspeak
 (setq espeak-default-speech-rate 820
       emacspeak-character-echo nil ;; Don't speak characters
- emac   emacspeak-m-player-program "/usr/bin/mplayer"))
+    emacspeak-m-player-program "/usr/bin/mplayer"))
+
+(after! circe
+  (set-irc-server! "irc.libera.chat"
+    `(:tls t
+      :port 6697
+      :nic "sektor"
+      :sasl-username ,(+pass-get-user "irc/libera.chat")
+      :sasl-password (lambda (&rest _) (+pass-get-secret "irc/libera.chat"))
+      :channels ("#emacs" "#stumpwm" "#pleroma"))))
+
+(after! circe
+  (set-irc-server! "irc.talkabout.cf"
+    `(:tls t
+      :port 6697
+      :nic "sektor"
+      :sasl-username ,(+pass-get-user "irc/talkabout.cf")
+      :sasl-password (lambda (&rest _) (+pass-get-secret "irc/talkabout.cf"))
+    :channels ("#a11y")))
+)
+
+(after! circe
+  (set-irc-server! "irc.zeronode.net"
+    `(:tls t
+      :port 6697
+      :nic "sektor"
+      :sasl-username ,(+pass-get-user "irc/zeronode.net")
+      :sasl-password (lambda (&rest _) (+pass-get-secret "irc/zeronode.net"))
+      :channels ("#noagenda"))))

--- a/config.el
+++ b/config.el
@@ -1,41 +1,6 @@
-;; config.el, the configuration file for Doom Emacs.
-;; Generated from config.org, do not manually edit.
-
-(add-hook 'after-init-hook (load "~/.doom.d/esp-prepare.el"))
-
-(setq user-full-name "Hunter Jozwiak"
-user-mail-address "hunter.t.joz@gmail.com")
-
-(setq doom-theme 'doom-one)
-
-(setq org-directory "~/org")
-
-(setq display-line-numbers-type nil)
-
-(after! circe
-  (set-irc-server! "irc.libera.chat"
-    `(:tls t
-      :port 6697
-      :nic "sektor"
-      :sasl-username ,(+pass-get-user "irc/libera.chat")
-      :sasl-password (lambda (&rest _) (+pass-get-secret "irc/libera.chat"))
-      :channels ("#emacs" "#stumpwm" "#pleroma"))))
-
-(after! circe
-  (set-irc-server! "irc.talkabout.cf"
-    `(:tls t
-      :port 6697
-      :nic "sektor"
-      :sasl-username ,(+pass-get-user "irc/talkabout.cf")
-      :sasl-password (lambda (&rest _) (+pass-get-secret "irc/talkabout.cf"))
-    :channels ("#a11y")))
-)
-
-(after! circe
-  (set-irc-server! "irc.zeronode.net"
-    `(:tls t
-      :port 6697
-      :nic "sektor"
-      :sasl-username ,(+pass-get-user "irc/zeronode.net")
-      :sasl-password (lambda (&rest _) (+pass-get-secret "irc/zeronode.net"))
-      :channels ("#noagenda"))))
+;; In preparation for the loading of Emacspeak
+;; Set the speech rate, so as to not go insane.
+(after! emacspeak
+(setq espeak-default-speech-rate 820
+      emacspeak-character-echo nil ;; Don't speak characters
+ emac   emacspeak-m-player-program "/usr/bin/mplayer"))

--- a/config.el
+++ b/config.el
@@ -1,8 +1,6 @@
 ;; config.el, the configuration file for Doom Emacs.
 ;; Generated from config.org, do not manually edit.
 
-(add-hook 'after-init-hook (load "~/.doom.d/esp-prepare.el"))
-
 (setq user-full-name "Hunter Jozwiak"
 user-mail-address "hunter.t.joz@gmail.com")
 
@@ -12,12 +10,7 @@ user-mail-address "hunter.t.joz@gmail.com")
 
 (setq display-line-numbers-type nil)
 
-;; In preparation for the loading of Emacspeak
-;; Set the speech rate, so as to not go insane.
-(after! emacspeak
-(setq espeak-default-speech-rate 820
-      emacspeak-character-echo nil ;; Don't speak characters
-    emacspeak-m-player-program "/usr/bin/mplayer"))
+(add-hook 'after-init-hook (load "~/.doom.d/esp-prepare.el"))
 
 (after! circe
   (set-irc-server! "irc.libera.chat"

--- a/config.el
+++ b/config.el
@@ -10,7 +10,7 @@ user-mail-address "hunter.t.joz@gmail.com")
 
 (setq display-line-numbers-type nil)
 
-(add-hook 'after-init-hook (load "~/.doom.d/esp-prepare.el"))
+(add-hook 'after-init-hook (load "~/emacspeak/lisp/emacspeak-setup.el"))
 
 (setq! espeak-default-speech-rate 820
        emacspeak-character-echo nil

--- a/config.el
+++ b/config.el
@@ -12,6 +12,11 @@ user-mail-address "hunter.t.joz@gmail.com")
 
 (add-hook 'after-init-hook (load "~/.doom.d/esp-prepare.el"))
 
+(setq! espeak-default-speech-rate 820
+       emacspeak-character-echo nil
+       emacspeak-word-echo nil
+       emacspeak-m-player-program "/usr/bin/mplayer")
+
 (after! circe
   (set-irc-server! "irc.libera.chat"
     `(:tls t

--- a/config.org
+++ b/config.org
@@ -308,7 +308,7 @@ And lastly, the configuration file config.el.
 ** Emacspeak
 Now, let's get the Emacspeak software working with Doom. Per the suggestion from the issue on the Doom Emacs issue tracker, I will split out the Emacspeak loading logic into a separate file.
 #+begin_src emacs-lisp :tangle esp-prepare.el
-load-file "~/emacspeak/lisp/emacspeak-setup.el")
+(load "~/emacspeak/lisp/emacspeak-setup.el")
 #+end_src
 Now, we need to ensure that this file is loaded after initialization.
 #+begin_src  emacs-lisp
@@ -340,13 +340,13 @@ I don't really like to hear line numbers as I move, so I will turn them off.
 * Personalization
 ** Emacspeak
 Set up the Emacspeak environment to suit my tastes.
-#+begin_src common-lisp
+#+begin_src emacs-lisp
 ;; In preparation for the loading of Emacspeak
 ;; Set the speech rate, so as to not go insane.
 (after! emacspeak
 (setq espeak-default-speech-rate 820
       emacspeak-character-echo nil ;; Don't speak characters
- emac   emacspeak-m-player-program "/usr/bin/mplayer"))
+    emacspeak-m-player-program "/usr/bin/mplayer"))
 #+end_src
 ** IRC
 I hang out mostly on the Liberachat, Zeronode and Talkabout networks.

--- a/config.org
+++ b/config.org
@@ -305,16 +305,7 @@ And lastly, the configuration file config.el.
 ;; config.el, the configuration file for Doom Emacs.
 ;; Generated from config.org, do not manually edit.
 #+end_src
-** Emacspeak
-Now, let's get the Emacspeak software working with Doom. Per the suggestion from the issue on the Doom Emacs issue tracker, I will split out the Emacspeak loading logic into a separate file.
-#+begin_src emacs-lisp :tangle esp-prepare.el
-(load "~/emacspeak/lisp/emacspeak-setup.el")
-#+end_src
-Now, we need to ensure that this file is loaded after initialization.
-#+begin_src  emacs-lisp
-(add-hook 'after-init-hook (load "~/.doom.d/esp-prepare.el"))
-#+end_src
-** Remaining configuration
+* Remaining configuration
 The last bit of the migration is to copy over the last vestiges of the original configuration I had going before.
 *** Identification Information
 These values are used to identify me across Emacs.
@@ -339,14 +330,17 @@ I don't really like to hear line numbers as I move, so I will turn them off.
 #+end_src
 * Personalization
 ** Emacspeak
-Set up the Emacspeak environment to suit my tastes.
-#+begin_src emacs-lisp
-;; In preparation for the loading of Emacspeak
-;; Set the speech rate, so as to not go insane.
-(after! emacspeak
+In order to get Emacspeak working, we need to create a preparation file into which we will place code we want executed before start the software. In my case, I want my espeak to speak at 820, with no word or character echo.
+#+begin_src emacs-lisp :tangle esp-prepare.el
 (setq espeak-default-speech-rate 820
-      emacspeak-character-echo nil ;; Don't speak characters
-    emacspeak-m-player-program "/usr/bin/mplayer"))
+      emacspeak-character-echo nil
+      emacspeak-word-echo nil)
+(load "~/emacspeak/lisp/emacspeak-setup.el")
+#+end_src
+Sometimes though, we get modules that need post-configuration on account of a variable being undefined, so we will handle those in the configuration file and not in the preparation file.
+Now, we need to ensure that this file is loaded after initialization.
+#+begin_src  emacs-lisp
+(add-hook 'after-init-hook (load "~/.doom.d/esp-prepare.el"))
 #+end_src
 ** IRC
 I hang out mostly on the Liberachat, Zeronode and Talkabout networks.

--- a/config.org
+++ b/config.org
@@ -308,12 +308,7 @@ And lastly, the configuration file config.el.
 ** Emacspeak
 Now, let's get the Emacspeak software working with Doom. Per the suggestion from the issue on the Doom Emacs issue tracker, I will split out the Emacspeak loading logic into a separate file.
 #+begin_src emacs-lisp :tangle esp-prepare.el
-;; In preparation for the loading of Emacspeak
-;; Set the speech rate, so as to not go insane.
-(setq espeak-default-speech-rate 820
-      emacspeak-character-echo nil ;; Don't speak characters
- emac   emacspeak-m-player-program "/usr/bin/mplayer")
-(load-file "~/emacspeak/lisp/emacspeak-setup.el")
+load-file "~/emacspeak/lisp/emacspeak-setup.el")
 #+end_src
 Now, we need to ensure that this file is loaded after initialization.
 #+begin_src  emacs-lisp
@@ -343,6 +338,16 @@ I don't really like to hear line numbers as I move, so I will turn them off.
 (setq display-line-numbers-type nil)
 #+end_src
 * Personalization
+** Emacspeak
+Set up the Emacspeak environment to suit my tastes.
+#+begin_src common-lisp
+;; In preparation for the loading of Emacspeak
+;; Set the speech rate, so as to not go insane.
+(after! emacspeak
+(setq espeak-default-speech-rate 820
+      emacspeak-character-echo nil ;; Don't speak characters
+ emac   emacspeak-m-player-program "/usr/bin/mplayer"))
+#+end_src
 ** IRC
 I hang out mostly on the Liberachat, Zeronode and Talkabout networks.
 *** Libera.chat

--- a/config.org
+++ b/config.org
@@ -330,15 +330,18 @@ I don't really like to hear line numbers as I move, so I will turn them off.
 ** Emacspeak
 In order to get Emacspeak working, we need to create a preparation file into which we will place code we want executed before start the software. In my case, I want my espeak to speak at 820, with no word or character echo.
 #+begin_src emacs-lisp :tangle esp-prepare.el
-(setq espeak-default-speech-rate 820
-      emacspeak-character-echo nil
-      emacspeak-word-echo nil)
 (load "~/emacspeak/lisp/emacspeak-setup.el")
 #+end_src
-Sometimes though, we get modules that need post-configuration on account of a variable being undefined, so we will handle those in the configuration file and not in the preparation file.
-Now, we need to ensure that this file is loaded after initialization.
+Sometimes though, we get modules that need post-configuration on account of a variable being undefined, so we will handle those in the configuration file and not in the preparation file, this is where the setq! macro comes in handy.
+First, we need to ensure that this file is loaded after initialization.
 #+begin_src  emacs-lisp
 (add-hook 'after-init-hook (load "~/.doom.d/esp-prepare.el"))
+#+end_src
+#+begin_src emacs-lisp
+(setq! espeak-default-speech-rate 820
+       emacspeak-character-echo nil
+       emacspeak-word-echo nil
+       emacspeak-m-player-program "/usr/bin/mplayer")
 #+end_src
 ** IRC
 I hang out mostly on the Liberachat, Zeronode and Talkabout networks.

--- a/config.org
+++ b/config.org
@@ -328,14 +328,9 @@ I don't really like to hear line numbers as I move, so I will turn them off.
 (setq display-line-numbers-type nil)
 #+end_src
 ** Emacspeak
-In order to get Emacspeak working, we need to create a preparation file into which we will place code we want executed before start the software. In my case, I want my espeak to speak at 820, with no word or character echo.
-#+begin_src emacs-lisp :tangle esp-prepare.el
-(load "~/emacspeak/lisp/emacspeak-setup.el")
-#+end_src
-Sometimes though, we get modules that need post-configuration on account of a variable being undefined, so we will handle those in the configuration file and not in the preparation file, this is where the setq! macro comes in handy.
 First, we need to ensure that this file is loaded after initialization.
 #+begin_src  emacs-lisp
-(add-hook 'after-init-hook (load "~/.doom.d/esp-prepare.el"))
+(add-hook 'after-init-hook (load "~/emacspeak/lisp/emacspeak-setup.el"))
 #+end_src
 #+begin_src emacs-lisp
 (setq! espeak-default-speech-rate 820

--- a/config.org
+++ b/config.org
@@ -50,8 +50,7 @@ make clean
 make -j$(nproc --all)
 #+end_src
 And with that done, we should be ready to rock.
-* Configuration Steps
-** A Base Doom Configuration
+* The Original Initialization files
 Let's start off by getting an init.el file rolling, from which we will enable various Doom modules.
 #+begin_src emacs-lisp :tangle init.el
 ;;; init.el -*- lexical-binding: t; -*-
@@ -305,30 +304,29 @@ And lastly, the configuration file config.el.
 ;; config.el, the configuration file for Doom Emacs.
 ;; Generated from config.org, do not manually edit.
 #+end_src
-* Remaining configuration
-The last bit of the migration is to copy over the last vestiges of the original configuration I had going before.
-*** Identification Information
+* Personalization
+Now we can get into the meat and potatoes of configuring Doom Emacs, which is somewhat of an involved process. Here are some ideas you can use as a base, modifying them to suit your needs.
+** Identification Information
 These values are used to identify me across Emacs.
 #+begin_src  emacs-lisp
 (setq user-full-name "Hunter Jozwiak"
 user-mail-address "hunter.t.joz@gmail.com")
 #+end_src
-*** Visual Things
+** Visual Things
 The visual theme of Doom.
 #+begin_src emacs-lisp
 (setq doom-theme 'doom-one)
 #+end_src
-*** The Org Directory
+** The Org Directory
 Where I want my org things to go.
 #+begin_src emacs-lisp
 (setq org-directory "~/org")
 #+end_src
-*** Line Number Display
+** Line Number Display
 I don't really like to hear line numbers as I move, so I will turn them off.
 #+begin_src emacs-lisp
 (setq display-line-numbers-type nil)
 #+end_src
-* Personalization
 ** Emacspeak
 In order to get Emacspeak working, we need to create a preparation file into which we will place code we want executed before start the software. In my case, I want my espeak to speak at 820, with no word or character echo.
 #+begin_src emacs-lisp :tangle esp-prepare.el

--- a/esp-prepare.el
+++ b/esp-prepare.el
@@ -1,1 +1,4 @@
+(setq espeak-default-speech-rate 820
+      emacspeak-character-echo nil
+      emacspeak-word-echo nil)
 (load "~/emacspeak/lisp/emacspeak-setup.el")

--- a/esp-prepare.el
+++ b/esp-prepare.el
@@ -1,1 +1,0 @@
-(load "~/emacspeak/lisp/emacspeak-setup.el")

--- a/esp-prepare.el
+++ b/esp-prepare.el
@@ -1,4 +1,1 @@
-(setq espeak-default-speech-rate 820
-      emacspeak-character-echo nil
-      emacspeak-word-echo nil)
 (load "~/emacspeak/lisp/emacspeak-setup.el")

--- a/esp-prepare.el
+++ b/esp-prepare.el
@@ -1,6 +1,1 @@
-;; In preparation for the loading of Emacspeak
-;; Set the speech rate, so as to not go insane.
-(setq espeak-default-speech-rate 820
-      emacspeak-character-echo nil ;; Don't speak characters
- emac   emacspeak-m-player-program "/usr/bin/mplayer")
-(load-file "~/emacspeak/lisp/emacspeak-setup.el")
+load-file "~/emacspeak/lisp/emacspeak-setup.el")

--- a/esp-prepare.el
+++ b/esp-prepare.el
@@ -1,1 +1,1 @@
-load-file "~/emacspeak/lisp/emacspeak-setup.el")
+(load "~/emacspeak/lisp/emacspeak-setup.el")


### PR DESCRIPTION
Fixes #3.
The main goal here is to better organiize the configuratio document and get Emacspeak configuration somewhat nailed down. This will take time, but warrants a bit of research hence I made a branch for it. Will close the branch when I am finished with the reorg, probably sometime this evening.
- esp-prepare: move configuration out and prepare for refactoring.
- Fix some big mistaes I made.
- Start moving sections around to be better organized. Move the preparation code back into the esp-prepare.el file, so that things that need to be set before Emacspeak starts are ready.
